### PR TITLE
Add instance selection feature for Teams bot

### DIFF
--- a/src/teams-opencode-bot.js
+++ b/src/teams-opencode-bot.js
@@ -384,7 +384,7 @@ async function botLogic(context) {
 
           if (result.success && result.responses.length > 0) {
             for (const response of result.responses) {
-              await postToTeams(context, response);
+              await postToTeams(context, `**[${instanceId}]**\n\n${response}`);
             }
           } else if (!result.success) {
             await context.sendActivity({
@@ -468,7 +468,7 @@ async function botLogic(context) {
 
       if (result.success && result.responses.length > 0) {
         for (const response of result.responses) {
-          await postToTeams(context, response);
+          await postToTeams(context, `**[${targetInstanceId}]**\n\n${response}`);
         }
       } else if (!result.success) {
         await context.sendActivity({


### PR DESCRIPTION
## Summary
- Add user session state tracking to remember which instance each user has selected
- Implement `oc-select` command to choose an active instance for chat
- Route non-command messages to the user's selected instance
- Update `oc-list` to show which instance is currently selected (✅ marker)
- Add `oc-clear` command to deselect the current instance

## Usage
1. Start instances with `oc-start <name> <path>`
2. Select an instance with `oc-select <name>`
3. Send messages directly - they go to the selected instance
4. Use `oc-list` to see which instance is selected
5. Use `oc-clear` to deselect