### PR TITLE
Sprite backend: Fly Machines API + webhook streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,34 +61,54 @@ DISCORD_CLIENT_ID=your-client-id-here
 # OPENCODE_PATH=/home/yourusername/.opencode/bin/opencode
 
 # ===========================================
-# SPRITE CONFIGURATION (for Sprite-based execution)
+# SPRITE CONFIGURATION (Cloud VM execution on Fly.io)
 # ===========================================
-# Required for: src/sprite-core.js
-# Sprites are ephemeral micro-VMs for running agents in isolated environments
-# See: https://sprites.dev (runs on Fly.io)
+# Required for: src/sprite-bot.js, src/sprite-core.js
+# Sprites are ephemeral Fly Machines for running agents in isolated environments
+# See SPRITE_SETUP.md for full setup guide
 
-# Sprite API Token (from Sprite dashboard)
-# SPRITE_API_TOKEN=your-sprite-api-token
+# Chat provider to use: slack, teams, or discord
+CHAT_PROVIDER=slack
 
-# Optional: Sprite API base URL (default: https://api.sprites.dev/v1)
-# SPRITE_API_URL=https://api.sprites.dev/v1
+# Fly.io API token (from: fly tokens create deploy -x 999999h)
+FLY_API_TOKEN=your-fly-api-token
 
-# Optional: Base Docker image for Sprites (default: open-dispatch/agent:latest)
-# SPRITE_BASE_IMAGE=open-dispatch/agent:latest
+# Fly app name for Sprite Machines
+FLY_SPRITE_APP=your-fly-app-name
 
-# Optional: Preferred region for Sprites (default: iad)
-# SPRITE_REGION=iad
+# Default Docker image for Sprites (your agent image with sidecar installed)
+SPRITE_IMAGE=registry.fly.io/your-app/agent:latest
+
+# Optional: Webhook callback URL (default: http://open-dispatch.internal:8080)
+# Uses Fly.io 6PN private networking by default
+# OPEN_DISPATCH_URL=http://open-dispatch.internal:8080
+
+# Optional: Webhook server port (default: 8080)
+# WEBHOOK_PORT=8080
+
+# Optional: Preferred Fly.io region (default: iad)
+# FLY_REGION=iad
 
 # Optional: Agent type to run in Sprites: 'claude' or 'opencode' (default: claude)
 # SPRITE_AGENT_TYPE=claude
+
+# These env vars are passed through to Sprites automatically:
+# GH_TOKEN          — GitHub token for private repos and gh CLI (in Sprites)
+# ANTHROPIC_API_KEY — For Claude-based agents (in Sprites)
+# DATABASE_URL      — If your agents need database access (in Sprites)
 
 # ===========================================
 # WHICH BOT TO RUN?
 # ===========================================
 #
+# LOCAL MODE (agents run on your machine):
 # Slack + Claude Code:    npm start                    (src/bot.js)
 # Slack + OpenCode:       npm run start:opencode       (src/opencode-bot.js)
 # Teams + Claude Code:    npm run start:teams          (src/teams-bot.js)
 # Teams + OpenCode:       npm run start:teams:opencode (src/teams-opencode-bot.js)
 # Discord + Claude Code:  npm run start:discord        (src/discord-bot.js)
 # Discord + OpenCode:     npm run start:discord:opencode (src/discord-opencode-bot.js)
+#
+# SPRITE MODE (agents run in cloud VMs on Fly.io):
+# Any provider + Sprite:  npm run start:sprite         (src/sprite-bot.js)
+#   Set CHAT_PROVIDER=slack|teams|discord to choose provider

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ KEY COMMANDS:
 - npm run start:teams:opencode   → Teams + OpenCode (local)
 - npm run start:discord          → Discord + Claude Code (local)
 - npm run start:discord:opencode → Discord + OpenCode (local)
+- npm run start:sprite           → Any provider + Sprite cloud VMs (set CHAT_PROVIDER)
 
 SLASH COMMANDS (in chat):
 LOCAL MODE:
@@ -66,7 +67,7 @@ TROUBLESHOOTING:
 - No response → Bot not invited to channel, or /od-start not run
 - "Instance not found" → Bot restarted, run /od-start again
 - Discord slash commands not showing → Wait up to 1 hour for global commands
-- "No API token" for Sprites → Set SPRITE_API_TOKEN (Fly.io token)
+- "No API token" for Sprites → Set FLY_API_TOKEN (Fly.io token)
 - Sprite spawn failed → Check image exists, Fly.io token valid
 
 SUCCESS CRITERIA:
@@ -567,8 +568,14 @@ open-dispatch/
 │   ├── claude-core.js          # Claude CLI integration
 │   ├── opencode-core.js        # OpenCode CLI integration
 │   ├── sprite-core.js          # Sprite (ephemeral VM) integration
-│   ├── sprite-orchestrator.js  # Sprite API orchestration
+│   ├── sprite-orchestrator.js  # Fly Machines API orchestration
+│   ├── sprite-bot.js           # Provider-agnostic Sprite entry point
+│   ├── webhook-server.js       # Receives output from Sprites via webhooks
 │   └── job.js                  # Job tracking for Sprite executions
+├── sidecar/
+│   ├── sprite-reporter.sh      # Sprite entry point (clone, run, report)
+│   ├── output-relay.js         # Buffered stdout → webhook relay
+│   └── Dockerfile              # Sidecar image for COPY --from=
 ├── tests/
 │   ├── opencode-core.test.js   # Core logic tests
 │   └── chat-provider.test.js   # Provider architecture tests

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "dev:opencode": "node --watch src/opencode-bot.js",
     "dev:teams:opencode": "node --watch src/teams-opencode-bot.js",
     "dev:discord:opencode": "node --watch src/discord-opencode-bot.js",
+    "start:sprite": "node src/sprite-bot.js",
+    "dev:sprite": "node --watch src/sprite-bot.js",
     "test": "node --test tests/*.test.js"
   },
   "keywords": [

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,0 +1,33 @@
+# =============================================================================
+# Open-Dispatch Sidecar Image
+#
+# Minimal image containing the webhook relay scripts that Sprites use to
+# communicate back to Open-Dispatch. Users install these into their own
+# agent images via multi-stage COPY:
+#
+#   FROM ghcr.io/bobum/open-dispatch/sidecar:latest AS sidecar
+#   FROM your-base-image
+#   COPY --from=sidecar /sidecar/ /usr/local/bin/
+#
+# Contents:
+#   /sidecar/sprite-reporter    — Bash entry point (clone, run, report)
+#   /sidecar/output-relay.js    — Node.js buffered output relay
+# =============================================================================
+
+FROM node:22-slim
+
+# Install minimal dependencies for sprite-reporter.sh
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    jq \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy sidecar scripts to a well-known path
+COPY sprite-reporter.sh /sidecar/sprite-reporter
+COPY output-relay.js /sidecar/output-relay.js
+
+RUN chmod +x /sidecar/sprite-reporter
+
+# Default: run the reporter (users override CMD in their images)
+ENTRYPOINT ["/sidecar/sprite-reporter"]

--- a/sidecar/output-relay.js
+++ b/sidecar/output-relay.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * output-relay.js — Open-Dispatch Sidecar Output Relay
+ *
+ * Reads agent stdout line-by-line, buffers output, and POSTs chunks
+ * to Open-Dispatch's /webhooks/logs endpoint over Fly.io 6PN.
+ *
+ * Buffering: Accumulates text for up to 500ms or 20 lines (whichever
+ * comes first), then POSTs a single chunk. This avoids flooding
+ * Open-Dispatch with per-line HTTP requests.
+ *
+ * Usage (piped from agent):
+ *   claude --output-format stream-json -p "task" | node output-relay.js
+ *
+ * Required env vars:
+ *   JOB_ID            — Job identifier
+ *   JOB_TOKEN         — Auth token for webhook
+ *   OPEN_DISPATCH_URL — Webhook base URL
+ */
+
+'use strict';
+
+const { createInterface } = require('readline');
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const JOB_ID = process.env.JOB_ID;
+const JOB_TOKEN = process.env.JOB_TOKEN;
+const OPEN_DISPATCH_URL = process.env.OPEN_DISPATCH_URL;
+const FLUSH_INTERVAL_MS = 500;
+const MAX_BUFFER_LINES = 20;
+
+if (!JOB_ID || !JOB_TOKEN || !OPEN_DISPATCH_URL) {
+  console.error('[output-relay] Missing required env vars');
+  process.exit(1);
+}
+
+const webhookUrl = new URL('/webhooks/logs', OPEN_DISPATCH_URL);
+const transport = webhookUrl.protocol === 'https:' ? https : http;
+
+// ---------------------------------------------------------------------------
+// Buffer
+// ---------------------------------------------------------------------------
+
+let buffer = [];
+let flushTimer = null;
+
+function scheduleFlush() {
+  if (!flushTimer) {
+    flushTimer = setTimeout(flush, FLUSH_INTERVAL_MS);
+  }
+}
+
+function flush() {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+
+  if (buffer.length === 0) return;
+
+  const text = buffer.join('\n');
+  buffer = [];
+
+  postLog(text);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP POST (fire-and-forget, non-blocking)
+// ---------------------------------------------------------------------------
+
+function postLog(text) {
+  const payload = JSON.stringify({ jobId: JOB_ID, text });
+
+  const options = {
+    hostname: webhookUrl.hostname,
+    port: webhookUrl.port || (webhookUrl.protocol === 'https:' ? 443 : 80),
+    path: webhookUrl.pathname,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${JOB_TOKEN}`,
+      'Content-Length': Buffer.byteLength(payload)
+    },
+    timeout: 5000
+  };
+
+  const req = transport.request(options, (res) => {
+    // Drain response to free socket
+    res.resume();
+    if (res.statusCode !== 200) {
+      console.error(`[output-relay] Webhook returned ${res.statusCode}`);
+    }
+  });
+
+  req.on('error', (err) => {
+    console.error(`[output-relay] POST error: ${err.message}`);
+  });
+
+  req.on('timeout', () => {
+    req.destroy();
+    console.error('[output-relay] POST timed out');
+  });
+
+  req.write(payload);
+  req.end();
+}
+
+// ---------------------------------------------------------------------------
+// Read stdin line-by-line
+// ---------------------------------------------------------------------------
+
+const rl = createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity
+});
+
+rl.on('line', (line) => {
+  // Pass through to stdout (Fly.io logs capture)
+  process.stdout.write(line + '\n');
+
+  buffer.push(line);
+
+  if (buffer.length >= MAX_BUFFER_LINES) {
+    flush();
+  } else {
+    scheduleFlush();
+  }
+});
+
+rl.on('close', () => {
+  // Final flush on stream end
+  flush();
+});
+
+// Handle signals gracefully
+process.on('SIGTERM', () => {
+  flush();
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  flush();
+  process.exit(0);
+});

--- a/sidecar/sprite-reporter.sh
+++ b/sidecar/sprite-reporter.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# sprite-reporter.sh — Open-Dispatch Sidecar Entry Point
+#
+# Runs inside a Sprite (Fly Machine). Clones a repo, executes an agent command,
+# and POSTs output back to Open-Dispatch via HTTP webhooks over Fly.io 6PN.
+#
+# Required env vars (injected by Open-Dispatch at spawn time):
+#   JOB_ID              — Unique job identifier
+#   JOB_TOKEN           — Job-scoped auth token for webhook validation
+#   OPEN_DISPATCH_URL   — Webhook base URL (e.g., http://open-dispatch.internal:8080)
+#   COMMAND             — Agent command to execute
+#
+# Optional env vars:
+#   REPO                — GitHub repo to clone (owner/repo)
+#   BRANCH              — Git branch (default: main)
+#   GH_TOKEN            — GitHub token (for private repos and gh CLI)
+#   ANTHROPIC_API_KEY   — For Claude-based agents
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+post_log() {
+  local text="$1"
+  curl -sf -X POST "${OPEN_DISPATCH_URL}/webhooks/logs" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${JOB_TOKEN}" \
+    -d "$(jq -n --arg jobId "$JOB_ID" --arg text "$text" '{jobId: $jobId, text: $text}')" \
+    >/dev/null 2>&1 || true
+}
+
+post_status() {
+  local status="$1"
+  local exit_code="${2:-0}"
+  local error="${3:-}"
+  curl -sf -X POST "${OPEN_DISPATCH_URL}/webhooks/status" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${JOB_TOKEN}" \
+    -d "$(jq -n \
+      --arg jobId "$JOB_ID" \
+      --arg status "$status" \
+      --argjson exitCode "$exit_code" \
+      --arg error "$error" \
+      '{jobId: $jobId, status: $status, exitCode: $exitCode, error: $error}')" \
+    >/dev/null 2>&1 || true
+}
+
+post_artifact() {
+  local name="$1"
+  local url="$2"
+  local type="${3:-url}"
+  curl -sf -X POST "${OPEN_DISPATCH_URL}/webhooks/artifacts" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${JOB_TOKEN}" \
+    -d "$(jq -n \
+      --arg jobId "$JOB_ID" \
+      --arg name "$name" \
+      --arg url "$url" \
+      --arg type "$type" \
+      '{jobId: $jobId, artifacts: [{name: $name, url: $url, type: $type}]}')" \
+    >/dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+if [ -z "${JOB_ID:-}" ] || [ -z "${JOB_TOKEN:-}" ] || [ -z "${OPEN_DISPATCH_URL:-}" ]; then
+  echo "[sprite-reporter] ERROR: Missing required env vars (JOB_ID, JOB_TOKEN, OPEN_DISPATCH_URL)"
+  exit 1
+fi
+
+if [ -z "${COMMAND:-}" ]; then
+  post_status "failed" 1 "No COMMAND specified"
+  echo "[sprite-reporter] ERROR: No COMMAND specified"
+  exit 1
+fi
+
+echo "[sprite-reporter] Job ${JOB_ID} starting"
+post_status "running" 0
+
+# ---------------------------------------------------------------------------
+# Clone repository (if REPO is set)
+# ---------------------------------------------------------------------------
+
+WORKDIR="/workspace"
+mkdir -p "$WORKDIR"
+
+if [ -n "${REPO:-}" ]; then
+  echo "[sprite-reporter] Cloning ${REPO} (branch: ${BRANCH:-main})"
+  post_log "Cloning ${REPO} (branch: ${BRANCH:-main})..."
+
+  CLONE_URL="https://github.com/${REPO}.git"
+  if [ -n "${GH_TOKEN:-}" ]; then
+    CLONE_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+  fi
+
+  if ! git clone --depth 1 --branch "${BRANCH:-main}" "$CLONE_URL" "$WORKDIR" 2>&1; then
+    post_status "failed" 1 "Failed to clone ${REPO}"
+    echo "[sprite-reporter] ERROR: Clone failed"
+    exit 1
+  fi
+
+  echo "[sprite-reporter] Clone complete"
+  post_log "Clone complete. Running agent..."
+fi
+
+cd "$WORKDIR"
+
+# Configure git for the agent
+git config --global user.email "sprite@open-dispatch.dev"
+git config --global user.name "Open-Dispatch Sprite"
+
+# Make GH_TOKEN available to gh CLI
+if [ -n "${GH_TOKEN:-}" ]; then
+  export GITHUB_TOKEN="$GH_TOKEN"
+fi
+
+# ---------------------------------------------------------------------------
+# Run agent command, relay output via webhooks
+# ---------------------------------------------------------------------------
+
+echo "[sprite-reporter] Executing: ${COMMAND}"
+
+# Pipe agent stdout through output-relay.js for webhook delivery
+# Also tee to stdout so Fly.io built-in logs capture everything
+EXIT_CODE=0
+if command -v node >/dev/null 2>&1 && [ -f /usr/local/bin/output-relay.js ]; then
+  # Use Node.js relay for buffered webhook delivery
+  eval "$COMMAND" 2>&1 | tee /dev/stderr | node /usr/local/bin/output-relay.js || EXIT_CODE=$?
+else
+  # Fallback: line-by-line curl (slower, no buffering)
+  eval "$COMMAND" 2>&1 | while IFS= read -r line; do
+    echo "$line"
+    post_log "$line"
+  done || EXIT_CODE=$?
+  # Capture exit code from the command, not the while loop
+  EXIT_CODE=${PIPESTATUS[0]}
+fi
+
+# ---------------------------------------------------------------------------
+# Report final status
+# ---------------------------------------------------------------------------
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "[sprite-reporter] Job ${JOB_ID} completed successfully"
+  post_status "completed" 0
+else
+  echo "[sprite-reporter] Job ${JOB_ID} failed with exit code ${EXIT_CODE}"
+  post_status "failed" "$EXIT_CODE" "Agent exited with code ${EXIT_CODE}"
+fi
+
+exit "$EXIT_CODE"

--- a/src/job.js
+++ b/src/job.js
@@ -2,14 +2,11 @@
  * Job Module
  *
  * Represents a job submitted to run in a Sprite (ephemeral micro-VM).
- * Tracks metadata, status, logs, and artifacts for each job.
+ * Tracks metadata, status, logs, artifacts, and webhook callbacks.
  */
 
 const { randomUUID } = require('crypto');
 
-/**
- * Job status enumeration
- */
 const JobStatus = {
   QUEUED: 'queued',
   RUNNING: 'running',
@@ -17,78 +14,88 @@ const JobStatus = {
   FAILED: 'failed'
 };
 
-/**
- * Job class for tracking Sprite-based agent executions
- */
 class Job {
   /**
-   * Create a new Job
-   * @param {Object} params - Job parameters
-   * @param {string} [params.jobId] - Unique job identifier (auto-generated if not provided)
-   * @param {string} params.repo - GitHub repository URL
-   * @param {string} params.branch - Branch name to checkout
-   * @param {string} params.command - Command to execute in the Sprite
-   * @param {string} params.slackChannel - Slack channel ID for results
-   * @param {string} [params.projectDir] - Project directory path (optional, for local context)
+   * @param {Object} params
+   * @param {string} [params.jobId] - Auto-generated if not provided
+   * @param {string} params.repo - GitHub repository (owner/repo)
+   * @param {string} [params.branch] - Branch name (default: main)
+   * @param {string} params.command - Agent command to execute
+   * @param {string} params.channelId - Chat channel ID (provider-agnostic)
+   * @param {string} [params.projectDir] - Project directory path
    * @param {string} [params.userId] - User who initiated the job
-   * @param {string} [params.image] - Docker image to use for this job (overrides default)
+   * @param {string} [params.image] - Docker image override
+   * @param {string} [params.jobToken] - Job-scoped auth token for webhook validation
+   * @param {Function} [params.onMessage] - Callback for streaming output: (text) => Promise<void>
+   * @param {Function} [params.onComplete] - Callback when job finishes: (job) => Promise<void>
+   * @param {number} [params.timeoutMs] - Max job runtime in ms (default: 600000 / 10 min)
    */
-  constructor({ jobId, repo, branch, command, slackChannel, projectDir, userId, image }) {
+  constructor({ jobId, repo, branch, command, channelId, projectDir, userId, image, jobToken, onMessage, onComplete, timeoutMs }) {
     this.jobId = jobId || randomUUID();
     this.repo = repo;
     this.branch = branch || 'main';
     this.command = command;
-    this.slackChannel = slackChannel;
+    this.channelId = channelId;
     this.projectDir = projectDir || null;
     this.userId = userId || null;
     this.image = image || null;
+    this.jobToken = jobToken || null;
+    this.onMessage = onMessage || null;
+    this.onComplete = onComplete || null;
+    this.timeoutMs = timeoutMs || 600000;
     this.status = JobStatus.QUEUED;
     this.logs = [];
     this.artifacts = [];
     this.spriteId = null;
+    this.machineId = null;
     this.createdAt = new Date();
     this.startedAt = null;
     this.completedAt = null;
+    this.lastActivityAt = new Date();
     this.error = null;
     this.exitCode = null;
   }
 
   /**
    * Mark job as running
-   * @param {string} spriteId - The Sprite instance ID
+   * @param {string} machineId - Fly Machine ID
    */
-  start(spriteId) {
+  start(machineId) {
     this.status = JobStatus.RUNNING;
-    this.spriteId = spriteId;
+    this.machineId = machineId;
+    this.spriteId = machineId;
     this.startedAt = new Date();
+    this.lastActivityAt = new Date();
   }
 
   /**
    * Mark job as completed
-   * @param {number} [exitCode] - Process exit code
+   * @param {number} [exitCode]
    */
   complete(exitCode = 0) {
     this.status = JobStatus.COMPLETED;
     this.completedAt = new Date();
     this.exitCode = exitCode;
+    this.lastActivityAt = new Date();
   }
 
   /**
    * Mark job as failed
-   * @param {string} error - Error message
-   * @param {number} [exitCode] - Process exit code
+   * @param {string} error
+   * @param {number} [exitCode]
    */
   fail(error, exitCode = 1) {
     this.status = JobStatus.FAILED;
     this.completedAt = new Date();
     this.error = error;
     this.exitCode = exitCode;
+    this.lastActivityAt = new Date();
   }
 
   /**
-   * Append a log entry
-   * @param {string} message - Log message
-   * @param {string} [level] - Log level (info, warn, error)
+   * Append a log entry and update activity timestamp
+   * @param {string} message
+   * @param {string} [level]
    */
   addLog(message, level = 'info') {
     this.logs.push({
@@ -96,38 +103,36 @@ class Job {
       level,
       message
     });
+    this.lastActivityAt = new Date();
   }
 
   /**
-   * Add an artifact URL
-   * @param {Object} artifact - Artifact info
-   * @param {string} artifact.name - Artifact name
-   * @param {string} artifact.url - Artifact URL
-   * @param {string} [artifact.type] - Artifact type (screenshot, video, log, etc.)
+   * Add an artifact
+   * @param {Object} artifact
+   * @param {string} artifact.name
+   * @param {string} artifact.url
+   * @param {string} [artifact.type]
    */
   addArtifact({ name, url, type = 'file' }) {
-    this.artifacts.push({
-      name,
-      url,
-      type,
-      addedAt: new Date()
-    });
+    this.artifacts.push({ name, url, type, addedAt: new Date() });
+    this.lastActivityAt = new Date();
   }
 
   /**
-   * Get job duration in milliseconds
-   * @returns {number|null} Duration or null if not started
+   * Check if job has exceeded its timeout
+   * @returns {boolean}
    */
+  isTimedOut() {
+    if (this.status !== JobStatus.RUNNING) return false;
+    return (Date.now() - this.lastActivityAt.getTime()) > this.timeoutMs;
+  }
+
   getDuration() {
     if (!this.startedAt) return null;
     const endTime = this.completedAt || new Date();
     return endTime - this.startedAt;
   }
 
-  /**
-   * Get a summary of the job for display
-   * @returns {Object} Job summary
-   */
   toSummary() {
     return {
       jobId: this.jobId,
@@ -142,8 +147,7 @@ class Job {
   }
 
   /**
-   * Serialize job to JSON
-   * @returns {Object} JSON representation
+   * Serialize to JSON (skips callbacks and token)
    */
   toJSON() {
     return {
@@ -151,7 +155,7 @@ class Job {
       repo: this.repo,
       branch: this.branch,
       command: this.command,
-      slackChannel: this.slackChannel,
+      channelId: this.channelId,
       projectDir: this.projectDir,
       userId: this.userId,
       image: this.image,
@@ -159,44 +163,42 @@ class Job {
       logs: this.logs,
       artifacts: this.artifacts,
       spriteId: this.spriteId,
+      machineId: this.machineId,
       createdAt: this.createdAt,
       startedAt: this.startedAt,
       completedAt: this.completedAt,
+      lastActivityAt: this.lastActivityAt,
       error: this.error,
-      exitCode: this.exitCode
+      exitCode: this.exitCode,
+      timeoutMs: this.timeoutMs
     };
   }
 
-  /**
-   * Create a Job from JSON
-   * @param {Object} json - JSON representation
-   * @returns {Job} Job instance
-   */
   static fromJSON(json) {
     const job = new Job({
       jobId: json.jobId,
       repo: json.repo,
       branch: json.branch,
       command: json.command,
-      slackChannel: json.slackChannel,
+      channelId: json.channelId,
       projectDir: json.projectDir,
       userId: json.userId,
-      image: json.image
+      image: json.image,
+      timeoutMs: json.timeoutMs
     });
     job.status = json.status;
     job.logs = json.logs || [];
     job.artifacts = json.artifacts || [];
     job.spriteId = json.spriteId;
+    job.machineId = json.machineId;
     job.createdAt = new Date(json.createdAt);
     job.startedAt = json.startedAt ? new Date(json.startedAt) : null;
     job.completedAt = json.completedAt ? new Date(json.completedAt) : null;
+    job.lastActivityAt = json.lastActivityAt ? new Date(json.lastActivityAt) : new Date();
     job.error = json.error;
     job.exitCode = json.exitCode;
     return job;
   }
 }
 
-module.exports = {
-  Job,
-  JobStatus
-};
+module.exports = { Job, JobStatus };

--- a/src/sprite-bot.js
+++ b/src/sprite-bot.js
@@ -1,0 +1,123 @@
+/**
+ * Sprite Bot — Provider-Agnostic Entry Point
+ *
+ * Single entry point for running Open-Dispatch with Sprite (Fly Machine)
+ * backend and any chat provider (Slack, Teams, Discord).
+ *
+ * Usage:
+ *   CHAT_PROVIDER=slack node src/sprite-bot.js
+ *   CHAT_PROVIDER=teams node src/sprite-bot.js
+ *   CHAT_PROVIDER=discord node src/sprite-bot.js
+ *
+ * Required env vars:
+ *   CHAT_PROVIDER    — slack | teams | discord
+ *   FLY_API_TOKEN    — Fly.io API token
+ *   FLY_SPRITE_APP   — Fly app name for Sprites
+ *   SPRITE_IMAGE     — Default Docker image for Sprites
+ *
+ * Per-provider env vars (see SLACK_SETUP.md, TEAMS_SETUP.md, DISCORD_SETUP.md):
+ *   Slack:   SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET
+ *   Teams:   TEAMS_APP_ID, TEAMS_APP_PASSWORD
+ *   Discord: DISCORD_BOT_TOKEN, DISCORD_CLIENT_ID
+ */
+
+require('dotenv').config();
+
+const { createProvider } = require('./providers');
+const { createBotEngine } = require('./bot-engine');
+const { createInstanceManager } = require('./sprite-core');
+const { createWebhookServer } = require('./webhook-server');
+
+// ============================================
+// ENV VALIDATION
+// ============================================
+
+const REQUIRED = ['CHAT_PROVIDER', 'FLY_API_TOKEN', 'FLY_SPRITE_APP', 'SPRITE_IMAGE'];
+const missing = REQUIRED.filter(k => !process.env[k]);
+if (missing.length > 0) {
+  console.error(`Missing required env vars: ${missing.join(', ')}`);
+  console.error('See SPRITE_SETUP.md for configuration details.');
+  process.exit(1);
+}
+
+const CHAT_PROVIDER = process.env.CHAT_PROVIDER.toLowerCase();
+
+// ============================================
+// PROVIDER CONFIG
+// ============================================
+
+function getProviderConfig(name) {
+  switch (name) {
+    case 'slack':
+      return {
+        token: process.env.SLACK_BOT_TOKEN,
+        appToken: process.env.SLACK_APP_TOKEN,
+        signingSecret: process.env.SLACK_SIGNING_SECRET,
+        socketMode: true
+      };
+    case 'teams':
+      return {
+        appId: process.env.TEAMS_APP_ID,
+        appPassword: process.env.TEAMS_APP_PASSWORD
+      };
+    case 'discord':
+      return {
+        token: process.env.DISCORD_BOT_TOKEN,
+        clientId: process.env.DISCORD_CLIENT_ID,
+        guildId: process.env.DISCORD_GUILD_ID
+      };
+    default:
+      console.error(`Unknown CHAT_PROVIDER: ${name}. Use: slack, teams, discord`);
+      process.exit(1);
+  }
+}
+
+// ============================================
+// BOOT
+// ============================================
+
+(async () => {
+  // 1. Create chat provider
+  const providerConfig = getProviderConfig(CHAT_PROVIDER);
+  const chatProvider = createProvider(CHAT_PROVIDER, providerConfig);
+
+  // 2. Create Sprite backend
+  const aiBackend = createInstanceManager();
+
+  // 3. Create webhook server (receives callbacks from Sprites)
+  const webhookPort = parseInt(process.env.WEBHOOK_PORT || '8080', 10);
+  const webhookServer = createWebhookServer({
+    jobs: aiBackend.jobs,
+    port: webhookPort
+  });
+
+  // 4. Create bot engine
+  const bot = createBotEngine({
+    chatProvider,
+    aiBackend,
+    aiName: 'Sprite',
+    streamResponses: true
+  });
+
+  // 5. Start everything
+  await webhookServer.start();
+  aiBackend.startStaleReaper();
+  await bot.start();
+
+  console.log(`[sprite-bot] Running with ${CHAT_PROVIDER} provider`);
+  console.log(`[sprite-bot] Webhook server on port ${webhookPort}`);
+  console.log(`[sprite-bot] Sprite app: ${process.env.FLY_SPRITE_APP}`);
+  console.log(`[sprite-bot] Default image: ${process.env.SPRITE_IMAGE}`);
+
+  // 6. Graceful shutdown
+  const shutdown = async (signal) => {
+    console.log(`\n[sprite-bot] ${signal} received, shutting down...`);
+    aiBackend.stopStaleReaper();
+    await bot.stop();
+    await webhookServer.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+})();

--- a/src/webhook-server.js
+++ b/src/webhook-server.js
@@ -1,0 +1,217 @@
+/**
+ * Webhook Server
+ *
+ * HTTP server that receives callbacks from Sprites over the Fly.io private network.
+ * Sprites POST agent output, status changes, and artifacts back to Open-Dispatch
+ * via these endpoints instead of relying on stdout polling.
+ *
+ * Runs on port 8080 (separate from chat provider ports).
+ */
+
+const http = require('http');
+
+/**
+ * Create a webhook server.
+ * @param {Object} options
+ * @param {Map} options.jobs - Map of jobId → Job objects (from sprite-core)
+ * @param {number} [options.port] - Listen port (default: 8080)
+ * @returns {Object} { server, start(), stop() }
+ */
+function createWebhookServer({ jobs, port = 8080 }) {
+  const server = http.createServer(async (req, res) => {
+    // CORS and content type
+    res.setHeader('Content-Type', 'application/json');
+
+    if (req.method === 'GET' && req.url === '/health') {
+      return respond(res, 200, {
+        status: 'healthy',
+        jobs: jobs.size,
+        uptime: process.uptime()
+      });
+    }
+
+    if (req.method === 'POST' && req.url === '/webhooks/logs') {
+      return handleLogs(req, res);
+    }
+
+    if (req.method === 'POST' && req.url === '/webhooks/status') {
+      return handleStatus(req, res);
+    }
+
+    if (req.method === 'POST' && req.url === '/webhooks/artifacts') {
+      return handleArtifacts(req, res);
+    }
+
+    respond(res, 404, { error: 'Not found' });
+  });
+
+  /**
+   * Parse JSON body from request.
+   */
+  function parseBody(req) {
+    return new Promise((resolve, reject) => {
+      let data = '';
+      req.on('data', chunk => { data += chunk; });
+      req.on('end', () => {
+        try {
+          resolve(data ? JSON.parse(data) : {});
+        } catch (e) {
+          reject(new Error('Invalid JSON'));
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+
+  /**
+   * Validate job token from Authorization header.
+   * Returns the Job if valid, or null.
+   */
+  function authenticateJob(req, jobId) {
+    const auth = req.headers['authorization'] || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+
+    if (!jobId || !token) return null;
+
+    const job = jobs.get(jobId);
+    if (!job) return null;
+    if (job.jobToken !== token) return null;
+
+    return job;
+  }
+
+  function respond(res, status, body) {
+    res.writeHead(status);
+    res.end(JSON.stringify(body));
+  }
+
+  /**
+   * POST /webhooks/logs — real-time agent output
+   * Body: { jobId, text }
+   */
+  async function handleLogs(req, res) {
+    let body;
+    try {
+      body = await parseBody(req);
+    } catch {
+      return respond(res, 400, { error: 'Invalid JSON' });
+    }
+
+    const { jobId, text } = body;
+    if (!jobId || !text) {
+      return respond(res, 400, { error: 'Missing jobId or text' });
+    }
+
+    const job = authenticateJob(req, jobId);
+    if (!job) {
+      return respond(res, 401, { error: 'Unauthorized' });
+    }
+
+    job.addLog(text);
+
+    // Fire the onMessage callback (streams to chat)
+    if (job.onMessage) {
+      try {
+        await job.onMessage(text);
+      } catch (e) {
+        console.error(`[Webhook] onMessage error for job ${jobId}:`, e.message);
+      }
+    }
+
+    respond(res, 200, { ok: true });
+  }
+
+  /**
+   * POST /webhooks/status — job state transitions
+   * Body: { jobId, status, exitCode, error }
+   */
+  async function handleStatus(req, res) {
+    let body;
+    try {
+      body = await parseBody(req);
+    } catch {
+      return respond(res, 400, { error: 'Invalid JSON' });
+    }
+
+    const { jobId, status, exitCode, error } = body;
+    if (!jobId || !status) {
+      return respond(res, 400, { error: 'Missing jobId or status' });
+    }
+
+    const job = authenticateJob(req, jobId);
+    if (!job) {
+      return respond(res, 401, { error: 'Unauthorized' });
+    }
+
+    if (status === 'completed') {
+      job.complete(exitCode || 0);
+    } else if (status === 'failed') {
+      job.fail(error || 'Sprite reported failure', exitCode || 1);
+    } else if (status === 'running') {
+      // Already running, just update activity
+      job.lastActivityAt = new Date();
+    }
+
+    // Fire the onComplete callback (resolves the sendToInstance Promise)
+    if (job.onComplete && (status === 'completed' || status === 'failed')) {
+      try {
+        await job.onComplete(job);
+      } catch (e) {
+        console.error(`[Webhook] onComplete error for job ${jobId}:`, e.message);
+      }
+    }
+
+    respond(res, 200, { ok: true });
+  }
+
+  /**
+   * POST /webhooks/artifacts — PR URLs, screenshots, test logs
+   * Body: { jobId, artifacts: [{ name, url, type }] }
+   */
+  async function handleArtifacts(req, res) {
+    let body;
+    try {
+      body = await parseBody(req);
+    } catch {
+      return respond(res, 400, { error: 'Invalid JSON' });
+    }
+
+    const { jobId, artifacts } = body;
+    if (!jobId || !Array.isArray(artifacts)) {
+      return respond(res, 400, { error: 'Missing jobId or artifacts array' });
+    }
+
+    const job = authenticateJob(req, jobId);
+    if (!job) {
+      return respond(res, 401, { error: 'Unauthorized' });
+    }
+
+    for (const artifact of artifacts) {
+      if (artifact.name && artifact.url) {
+        job.addArtifact(artifact);
+      }
+    }
+
+    respond(res, 200, { ok: true, count: artifacts.length });
+  }
+
+  return {
+    server,
+    start() {
+      return new Promise((resolve, reject) => {
+        server.listen(port, () => {
+          console.log(`[Webhook] Server listening on port ${port}`);
+          resolve();
+        });
+        server.on('error', reject);
+      });
+    },
+    stop() {
+      return new Promise((resolve) => {
+        server.close(resolve);
+      });
+    }
+  };
+}
+
+module.exports = { createWebhookServer };


### PR DESCRIPTION
## Summary

- Migrate Sprite orchestrator from fictional `sprites.dev` API to real Fly.io Machines API (`api.machines.dev`)
- Replace stdout polling with **HTTP webhook streaming** — Sprites POST output back to Open-Dispatch over Fly.io 6PN private networking
- Add webhook server (`/webhooks/logs`, `/webhooks/status`, `/webhooks/artifacts`) with per-job auth tokens
- Add provider-agnostic entry point (`sprite-bot.js`) — single binary supports Slack, Teams, and Discord via `CHAT_PROVIDER` env var
- Add message batching in bot-engine (500ms/5-line buffer, 200ms rate limit between chat API calls)
- Add sidecar scripts (`sidecar/`) for Sprite-side webhook relay — users install via `COPY --from=ghcr.io/bobum/open-dispatch/sidecar:latest`
- Rename `slackChannel` → `channelId` throughout for provider-agnostic code

### Architecture

```
Open-Dispatch (host)         Sprite Machine (ephemeral)
┌──────────────────┐         ┌──────────────────────────┐
│ bot-engine        │         │ sprite-reporter (sidecar) │
│   onMessage() ◄──┼─────────┼── POST /webhooks/logs     │
│                   │  6PN    │   POST /webhooks/status   │
│ webhook-server    │◄────────┤   POST /webhooks/artifacts│
│   :8080           │         └──────────────────────────┘
└──────────────────┘
```

### New files
| File | Purpose |
|------|---------|
| `src/webhook-server.js` | HTTP server receiving agent output from Sprites |
| `src/sprite-bot.js` | Provider-agnostic Sprite mode entry point |
| `sidecar/sprite-reporter.sh` | Sprite entry point: clone, run agent, report |
| `sidecar/output-relay.js` | Buffered stdout → webhook relay |
| `sidecar/Dockerfile` | Sidecar image for `COPY --from=` installation |

### Modified files
| File | Changes |
|------|---------|
| `src/sprite-orchestrator.js` | Fly Machines API, job token generation |
| `src/sprite-core.js` | Webhook callback pattern, stale job reaper |
| `src/job.js` | `channelId`, `jobToken`, callbacks, timeouts |
| `src/bot-engine.js` | Message batcher, `await` fixes |
| `package.json` | `start:sprite`, `dev:sprite` scripts |
| `.env.example` | New Fly.io + webhook env vars |
| `SPRITE_SETUP.md` | Full rewrite for Fly Machines + sidecar |
| `README.md` | Updated project structure and commands |

Relates to #10, #15

## Test plan

- [ ] `CHAT_PROVIDER=slack node src/sprite-bot.js` starts without errors (with mock env vars)
- [ ] `curl localhost:8080/health` returns 200
- [ ] No references to `api.sprites.dev` in src/ (except clarifying comment)
- [ ] No references to `slackChannel` in sprite-related files
- [ ] POST to `/webhooks/logs` with valid job token → 200, `onMessage` callback fires
- [ ] POST to `/webhooks/logs` with bad token → 401
- [ ] POST to `/webhooks/status` with `{status: "completed"}` → job Promise resolves
- [ ] POST to `/webhooks/artifacts` → artifacts stored on job
- [ ] Pipe fake NDJSON through `sidecar/output-relay.js` → verify it POSTs to webhook URL
- [ ] `sidecar/Dockerfile` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)