### PR TITLE
Unify OD commands — same syntax, any backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,13 @@ KEY COMMANDS - SPRITE MODE (container on Fly.io):
 - npm run start:sprite           → Any provider (set CHAT_PROVIDER=slack|teams|discord)
 - fly deploy                     → Deploy to Fly.io
 
-SLASH COMMANDS (in chat):
-LOCAL MODE:
-- /od-start <name> <path>  → Start local instance bound to channel
-- /od-stop <name>          → Stop instance
-- /od-list                 → List instances
-- /od-send <name> <msg>    → Send to specific instance
-
-SPRITE MODE:
-- /od-run [options] <task> → One-shot: spawn VM, run task, terminate
-  Options: --repo <url>, --branch <name>, --image <docker-image>
-- /od-start <name> --repo <url> --persistent → Persistent VM session
-- /od-jobs                 → List recent Sprite jobs
+SLASH COMMANDS (unified — same syntax in any mode):
+- /od-start [name] [--image <alias>] [path] → Start a conversation agent
+- /od-run [--image <alias>] <task>           → One-shot fire-and-forget task
+- /od-stop <name> | --all                    → Stop agent(s)
+- /od-list                                   → List active agents
+- /od-send <name> <msg>                      → Send to specific instance
+- /od-jobs                                   → List recent jobs (Sprite mode)
 
 TROUBLESHOOTING:
 LOCAL MODE:
@@ -82,6 +77,7 @@ SPRITE MODE:
 SUCCESS CRITERIA:
 - Local: User can /od-start and send messages from phone
 - Sprites: User can /od-run a task and see streamed results in chat
+- Same commands work in both modes (no need to know which backend)
 ```
 
 ---
@@ -205,7 +201,7 @@ cp .env.example .env
 npm run start:opencode    # Slack + OpenCode (recommended)
 
 # 4. In Slack, start a session
-/od-start myproject /path/to/code
+/od-start myproject ~/projects/mycode
 
 # 5. Chat normally—AI responds in channel
 ```
@@ -396,10 +392,12 @@ npm run start:discord
 
 | Command | Description |
 |---------|-------------|
-| `/od-start` | Start an AI instance |
-| `/od-stop` | Stop an AI instance |
-| `/od-list` | List running instances |
-| `/od-send` | Send message to instance |
+| `/od-start` | Start an AI agent |
+| `/od-stop` | Stop an AI agent |
+| `/od-list` | List running agents |
+| `/od-send` | Send message to agent |
+| `/od-run` | Run a one-shot task |
+| `/od-jobs` | List recent jobs |
 
 > **Note:** Leave Request URL blank for all (Socket Mode handles it)
 
@@ -432,38 +430,35 @@ npm run start:opencode
 
 ```bash
 # In Slack:
-/invite @Open Dispatch          # Invite bot to channel
-/od-start myproject /path/to/code   # Start instance
-"What files are in this project?"   # Chat normally!
+/invite @Open Dispatch             # Invite bot to channel
+/od-start myproject ~/projects/api # Start instance (name + path)
+"What files are in this project?"  # Chat normally!
 ```
 
 ---
 
 ## 💻 Commands
 
-### Local Mode Commands
+Same commands, same syntax — works in both Local and Sprite mode.
 
 | Command | Example | Description |
 |---------|---------|-------------|
-| `/od-start` | `/od-start api ~/projects/api` | Start instance named "api" in that directory |
-| `/od-stop` | `/od-stop api` | Stop the "api" instance |
-| `/od-list` | `/od-list` | Show all running instances |
-| `/od-send` | `/od-send api add tests` | Send message to "api" from any channel |
+| `/od-start` | `/od-start` | Start agent with auto-generated name, default path |
+| `/od-start` | `/od-start mybot` | Start named agent in `$HOME` |
+| `/od-start` | `/od-start mybot ~/projects/api` | Named agent in specific directory |
+| `/od-start` | `/od-start --image custom-agent` | Auto-named agent with custom image (Sprite) |
+| `/od-run` | `/od-run "run the tests"` | One-shot fire-and-forget task |
+| `/od-run` | `/od-run --image my-agent:v1 "lint the code"` | One-shot with custom image |
+| `/od-stop` | `/od-stop mybot` | Stop a specific agent |
+| `/od-stop` | `/od-stop --all` | Stop all running agents |
+| `/od-list` | `/od-list` | List active agents |
+| `/od-send` | `/od-send mybot add tests` | Send message to specific agent |
+| `/od-jobs` | `/od-jobs` | List recent jobs (Sprite mode only) |
 
-### Sprite Mode Commands (Cloud VMs)
-
-| Command | Example | Description |
-|---------|---------|-------------|
-| `/od-run` | `/od-run --repo github.com/user/proj "run tests"` | One-shot job in fresh Sprite |
-| `/od-run` | `/od-run --image my-agent:v1 --repo ... "task"` | One-shot with custom image |
-| `/od-start` | `/od-start bot --repo github.com/user/proj --persistent` | Persistent Sprite session |
-| `/od-jobs` | `/od-jobs` | List recent Sprite jobs |
-
-**Sprite Options:**
-- `--repo <url>` - GitHub repository to clone
-- `--branch <name>` - Branch to checkout (default: main)
-- `--image <image>` - Docker image to use
-- `--persistent` - Keep Sprite alive for multiple messages
+**Options:**
+- `--image <alias>` — Docker image to use (Sprite mode uses it, Local mode ignores it)
+- `name` — Optional everywhere; auto-generates short unique ID if omitted
+- `path` — Optional in `/od-start`; defaults to `$HOME` (Local mode), ignored in Sprite mode
 
 ### Chat Messages
 
@@ -578,7 +573,7 @@ Fly.io Private Network (6PN / WireGuard mesh)
 ```
 
 **How Sprite execution works:**
-1. User runs `/od-run --repo owner/project "run the tests"` in chat
+1. User runs `/od-run "run the tests"` in chat
 2. Open Dispatch creates a Job with a unique ID and per-job auth token
 3. Sprite Orchestrator spawns a Fly Machine via the [Machines API](https://fly.io/docs/machines/api/)
 4. The Sprite's sidecar (`sprite-reporter`) clones the repo and runs the agent
@@ -743,7 +738,7 @@ docker build -t registry.fly.io/your-sprite-app/agent:latest .
 docker push registry.fly.io/your-sprite-app/agent:latest
 ```
 
-**That's it.** Run `/od-run --repo owner/project "run the tests"` in chat and watch output stream back in real-time.
+**That's it.** Run `/od-run "run the tests"` in chat and watch output stream back in real-time.
 
 ---
 
@@ -758,7 +753,7 @@ docker push registry.fly.io/your-sprite-app/agent:latest
 | `"Instance not found"` | Bot was restarted. Run `/od-start` again |
 | Slow responses | Normal — each message spawns a process. ~2-5 sec |
 | Teams webhook fails | Check ngrok is running and URL updated in Dev Portal |
-| `/od-run` says "requires Sprite backend" | You're in local mode. Use `/od-start` instead, or switch to Sprite mode |
+| `/od-run` doesn't stream output | In local mode, `/od-run` runs the task and returns the result when done |
 
 ### Sprite Mode
 
@@ -824,6 +819,7 @@ open-dispatch/
 │   ├── output-relay.js         # Buffered stdout → webhook relay
 │   └── Dockerfile              # Sidecar image for COPY --from=
 ├── tests/
+│   ├── bot-engine.test.js      # Unified command parsing tests
 │   ├── chat-provider.test.js   # Provider architecture tests
 │   ├── job.test.js             # Job tracking tests
 │   ├── opencode-core.test.js   # Core logic tests
@@ -848,7 +844,7 @@ open-dispatch/
 npm test
 ```
 
-156+ tests covering:
+173+ tests covering:
 - Instance lifecycle
 - Output parsing (JSON, ndjson, plaintext)
 - Message chunking

--- a/src/bot-engine.js
+++ b/src/bot-engine.js
@@ -5,6 +5,9 @@
  * Handles command parsing, instance routing, and response formatting.
  */
 
+const os = require('os');
+const { randomBytes } = require('crypto');
+
 /**
  * @typedef {Object} BotEngineOptions
  * @property {import('./providers/chat-provider').ChatProvider} chatProvider - Chat platform provider
@@ -111,41 +114,48 @@ function createBotEngine(options) {
   // ============================================
 
   /**
+   * Generate a short unique name for auto-named agents.
+   * @returns {string} e.g. "agent-7k3f"
+   */
+  function generateName() {
+    return 'agent-' + randomBytes(2).toString('hex');
+  }
+
+  /**
    * Handle the 'start' command
+   * Usage: /od-start [name] [--image alias] [path]
    */
   async function handleStart(ctx, args) {
-    const parts = args.trim().split(/\s+/);
+    const parsed = parseStartArgs(args);
+    const instanceId = parsed.name || generateName();
+    const projectDir = parsed.path || os.homedir();
+    const opts = {};
+    if (parsed.image) opts.image = parsed.image;
 
-    if (parts.length < 2) {
-      await ctx.reply(
-        `Usage: \`${commandPrefix}-start <instance-name> <project-directory>\``
-      );
-      return;
-    }
-
-    const [instanceId, ...pathParts] = parts;
-    const projectDir = pathParts.join(' ');
-
-    const result = await aiBackend.startInstance(instanceId, projectDir, ctx.channelId);
+    const result = await aiBackend.startInstance(instanceId, projectDir, ctx.channelId, opts);
 
     if (result.success) {
       if (chatProvider.supportsCards) {
+        const fields = [
+          { name: 'Instance', value: instanceId, inline: true },
+          { name: 'Project', value: projectDir, inline: true },
+          { name: 'Session', value: result.sessionId.substring(0, 8) + '...', inline: true }
+        ];
+        if (parsed.image) {
+          fields.push({ name: 'Image', value: parsed.image, inline: true });
+        }
         await chatProvider.sendCard(ctx.channelId, {
           title: `${aiName} Instance Started`,
           color: '#00ff00',
-          fields: [
-            { name: 'Instance', value: instanceId, inline: true },
-            { name: 'Project', value: projectDir, inline: true },
-            { name: 'Session', value: result.sessionId.substring(0, 8) + '...', inline: true }
-          ],
+          fields,
           footer: `Messages in this channel will be sent to ${aiName}.`
         });
       } else {
-        await ctx.reply(
-          `Started instance **${instanceId}** in \`${projectDir}\`\n` +
-          `Session: \`${result.sessionId}\`\n\n` +
-          `Messages in this channel will be sent to ${aiName}.`
-        );
+        let msg = `Started instance **${instanceId}** in \`${projectDir}\`\n` +
+          `Session: \`${result.sessionId}\``;
+        if (parsed.image) msg += `\nImage: ${parsed.image}`;
+        msg += `\n\nMessages in this channel will be sent to ${aiName}.`;
+        await ctx.reply(msg);
       }
     } else {
       if (chatProvider.supportsCards) {
@@ -161,13 +171,76 @@ function createBotEngine(options) {
   }
 
   /**
+   * Parse /od-start arguments
+   * @param {string} args - Raw argument string
+   * @returns {Object} Parsed { name, image, path }
+   */
+  function parseStartArgs(args) {
+    const result = { name: null, image: null, path: null };
+    let remaining = args.trim();
+    if (!remaining) return result;
+
+    // Extract --image value
+    const imageMatch = remaining.match(/--image\s+(\S+)/);
+    if (imageMatch) {
+      result.image = imageMatch[1];
+      remaining = remaining.replace(/--image\s+\S+/, '').trim();
+    }
+
+    if (!remaining) return result;
+
+    // Remaining tokens: [name] [path]
+    // Path starts with / or ~ or is a known home dir pattern
+    const tokens = remaining.split(/\s+/);
+    if (tokens.length === 0) return result;
+
+    // If first token looks like a path, it's the path (no name given)
+    if (tokens[0].startsWith('/') || tokens[0].startsWith('~')) {
+      result.path = tokens.join(' ');
+    } else {
+      result.name = tokens[0];
+      if (tokens.length > 1) {
+        result.path = tokens.slice(1).join(' ');
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Handle the 'stop' command
+   * Usage: /od-stop <name> | --all
    */
   async function handleStop(ctx, args) {
-    const instanceId = args.trim();
+    const trimmed = args.trim();
+
+    if (trimmed === '--all') {
+      const instances = aiBackend.listInstances();
+      if (instances.length === 0) {
+        await ctx.reply('No instances running.');
+        return;
+      }
+      const stopped = [];
+      for (const inst of instances) {
+        const r = aiBackend.stopInstance(inst.instanceId);
+        if (r.success) stopped.push(inst.instanceId);
+      }
+      if (chatProvider.supportsCards) {
+        await chatProvider.sendCard(ctx.channelId, {
+          title: `${aiName} — Stopped All`,
+          color: '#ff9900',
+          description: `Stopped ${stopped.length} instance(s): ${stopped.join(', ')}`
+        });
+      } else {
+        await ctx.reply(`Stopped ${stopped.length} instance(s): ${stopped.join(', ')}`);
+      }
+      return;
+    }
+
+    const instanceId = trimmed;
 
     if (!instanceId) {
-      await ctx.reply(`Usage: \`${commandPrefix}-stop <instance-name>\``);
+      await ctx.reply(`Usage: \`${commandPrefix}-stop <name>\` or \`${commandPrefix}-stop --all\``);
       return;
     }
 
@@ -206,7 +279,7 @@ function createBotEngine(options) {
       if (chatProvider.supportsCards) {
         await chatProvider.sendCard(ctx.channelId, {
           title: 'No Running Instances',
-          description: `Use \`${commandPrefix}-start <name> <project-path>\` to start a new instance.`
+          description: `Use \`${commandPrefix}-start [name] [path]\` to start a new instance.`
         });
       } else {
         await ctx.reply('No instances running.');
@@ -258,35 +331,26 @@ function createBotEngine(options) {
   }
 
   /**
-   * Handle the 'run' command (one-shot Sprite execution)
-   * Usage: /od-run [--image <image>] [--repo <repo>] [--branch <branch>] <task>
+   * Handle the 'run' command (one-shot fire-and-forget)
+   * Usage: /od-run [--image <image>] <task>
    */
   async function handleRun(ctx, args) {
-    // Check if backend supports run (has jobs - sprite-core)
-    if (!aiBackend.jobs) {
-      await ctx.reply(
-        `The \`${commandPrefix}-run\` command requires Sprite backend.\n` +
-        `Current backend doesn't support one-shot job execution.`
-      );
-      return;
-    }
-
     // Parse options and task from args
     const parsed = parseRunArgs(args);
 
     if (!parsed.task) {
       await ctx.reply(
-        `Usage: \`${commandPrefix}-run [--image <image>] [--repo <repo>] [--branch <branch>] <task>\`\n\n` +
+        `Usage: \`${commandPrefix}-run [--image <image>] <task>\`\n\n` +
         `**Examples:**\n` +
-        `\`${commandPrefix}-run --repo github.com/user/project "run the tests"\`\n` +
-        `\`${commandPrefix}-run --image my-agent:v1 --repo github.com/user/project "lint the code"\``
+        `\`${commandPrefix}-run "run the tests"\`\n` +
+        `\`${commandPrefix}-run --image my-agent:v1 "lint the code"\``
       );
       return;
     }
 
     // Create a temporary instance for this job
-    const instanceId = `run-${Date.now()}`;
-    const projectDir = parsed.repo || '';
+    const instanceId = generateName();
+    const projectDir = os.homedir();
 
     const startResult = await aiBackend.startInstance(instanceId, projectDir, ctx.channelId);
     if (!startResult.success) {
@@ -301,16 +365,12 @@ function createBotEngine(options) {
         color: '#0099ff',
         fields: [
           { name: 'Task', value: parsed.task, inline: false },
-          parsed.repo && { name: 'Repo', value: parsed.repo, inline: true },
-          parsed.branch && { name: 'Branch', value: parsed.branch, inline: true },
           parsed.image && { name: 'Image', value: parsed.image, inline: true }
         ].filter(Boolean),
         footer: 'Streaming logs as they arrive...'
       });
     } else {
       let msg = `**Job Started**\nTask: ${parsed.task}`;
-      if (parsed.repo) msg += `\nRepo: ${parsed.repo}`;
-      if (parsed.branch) msg += `\nBranch: ${parsed.branch}`;
       if (parsed.image) msg += `\nImage: ${parsed.image}`;
       await ctx.reply(msg);
     }
@@ -327,8 +387,6 @@ function createBotEngine(options) {
     // Execute the job
     const result = await aiBackend.sendToInstance(instanceId, parsed.task, {
       onMessage,
-      repo: parsed.repo,
-      branch: parsed.branch,
       image: parsed.image
     });
 
@@ -384,33 +442,18 @@ function createBotEngine(options) {
   /**
    * Parse /od-run arguments
    * @param {string} args - Raw argument string
-   * @returns {Object} Parsed options { image, repo, branch, task }
+   * @returns {Object} Parsed options { image, task }
    */
   function parseRunArgs(args) {
-    const result = { image: null, repo: null, branch: null, task: null };
+    const result = { image: null, task: null };
     let remaining = args.trim();
 
-    // Extract --option value pairs
-    const optionRegex = /--(\w+)\s+(\S+)/g;
-    let match;
-
-    while ((match = optionRegex.exec(remaining)) !== null) {
-      const [fullMatch, option, value] = match;
-      switch (option.toLowerCase()) {
-        case 'image':
-          result.image = value;
-          break;
-        case 'repo':
-          result.repo = value;
-          break;
-        case 'branch':
-          result.branch = value;
-          break;
-      }
+    // Extract --image value
+    const imageMatch = remaining.match(/--image\s+(\S+)/);
+    if (imageMatch) {
+      result.image = imageMatch[1];
+      remaining = remaining.replace(/--image\s+\S+/, '').trim();
     }
-
-    // Remove all --option value pairs to get the task
-    remaining = remaining.replace(/--\w+\s+\S+/g, '').trim();
 
     // Task can be quoted or unquoted
     if (remaining.startsWith('"') && remaining.endsWith('"')) {
@@ -418,7 +461,7 @@ function createBotEngine(options) {
     } else if (remaining.startsWith("'") && remaining.endsWith("'")) {
       result.task = remaining.slice(1, -1);
     } else {
-      result.task = remaining;
+      result.task = remaining || null;
     }
 
     return result;
@@ -450,7 +493,7 @@ function createBotEngine(options) {
     if (chatProvider.supportsCards) {
       const fields = jobs.slice(-10).map((job) => ({
         name: `${job.jobId.substring(0, 8)}... (${job.status})`,
-        value: `${job.repo || 'N/A'}\n${job.artifactCount} artifacts`,
+        value: `${job.artifactCount} artifacts`,
         inline: false
       }));
 
@@ -461,7 +504,7 @@ function createBotEngine(options) {
       });
     } else {
       const lines = jobs.slice(-10).map((job) =>
-        `- **${job.jobId.substring(0, 8)}...** [${job.status}] - ${job.repo || 'N/A'}`
+        `- **${job.jobId.substring(0, 8)}...** [${job.status}]`
       );
       await ctx.reply(`**Recent Jobs:**\n${lines.join('\n')}`);
     }
@@ -603,11 +646,11 @@ function createBotEngine(options) {
         await ctx.reply(
           `Unknown command: ${command}\n\n` +
           `**Available commands:**\n` +
-          `- \`${commandPrefix}-start <name> <path>\` - Start an instance\n` +
-          `- \`${commandPrefix}-stop <name>\` - Stop an instance\n` +
-          `- \`${commandPrefix}-list\` - List instances\n` +
+          `- \`${commandPrefix}-start [name] [--image <alias>] [path]\` - Start a conversation\n` +
+          `- \`${commandPrefix}-run [--image <alias>] <task>\` - Run a one-shot task\n` +
+          `- \`${commandPrefix}-stop <name> | --all\` - Stop agent(s)\n` +
+          `- \`${commandPrefix}-list\` - List active agents\n` +
           `- \`${commandPrefix}-send <name> <message>\` - Send to instance\n` +
-          `- \`${commandPrefix}-run [options] <task>\` - Run one-shot job in Sprite\n` +
           `- \`${commandPrefix}-jobs\` - List recent jobs`
         );
     }
@@ -695,4 +738,4 @@ function createBotEngine(options) {
   };
 }
 
-module.exports = { createBotEngine };
+module.exports = { createBotEngine, _test: { generateName: () => 'agent-' + randomBytes(2).toString('hex') } };

--- a/src/bot-engine.js
+++ b/src/bot-engine.js
@@ -22,7 +22,7 @@ function generateName() {
  * Respects double and single quotes — content inside quotes
  * is kept as a single token with quotes stripped.
  * @param {string} input
- * @returns {string[]}
+ * @returns {string[] | {error: string}} Array of tokens, or object with error on parse failure
  */
 function tokenize(input) {
   const tokens = [];
@@ -470,6 +470,8 @@ function createBotEngine(options) {
         onMessage,
         image: parsed.image
       });
+    } catch (err) {
+      result = { success: false, error: err.message || String(err) };
     } finally {
       // Always clean up batcher and temp instance, even on error
       await batcher.flush();

--- a/src/claude-core.js
+++ b/src/claude-core.js
@@ -22,7 +22,7 @@ function createInstanceManager(options = {}) {
   /**
    * Start a new Claude Code instance
    */
-  function startInstance(instanceId, projectDir, channel) {
+  function startInstance(instanceId, projectDir, channel, opts = {}) {
     if (instances.has(instanceId)) {
       return { success: false, error: `Instance "${instanceId}" already running` };
     }

--- a/src/job.js
+++ b/src/job.js
@@ -18,8 +18,6 @@ class Job {
   /**
    * @param {Object} params
    * @param {string} [params.jobId] - Auto-generated if not provided
-   * @param {string} params.repo - GitHub repository (owner/repo)
-   * @param {string} [params.branch] - Branch name (default: main)
    * @param {string} params.command - Agent command to execute
    * @param {string} params.channelId - Chat channel ID (provider-agnostic)
    * @param {string} [params.projectDir] - Project directory path
@@ -30,10 +28,8 @@ class Job {
    * @param {Function} [params.onComplete] - Callback when job finishes: (job) => Promise<void>
    * @param {number} [params.timeoutMs] - Max job runtime in ms (default: 600000 / 10 min)
    */
-  constructor({ jobId, repo, branch, command, channelId, projectDir, userId, image, jobToken, onMessage, onComplete, timeoutMs }) {
+  constructor({ jobId, command, channelId, projectDir, userId, image, jobToken, onMessage, onComplete, timeoutMs }) {
     this.jobId = jobId || randomUUID();
-    this.repo = repo;
-    this.branch = branch || 'main';
     this.command = command;
     this.channelId = channelId;
     this.projectDir = projectDir || null;
@@ -136,8 +132,6 @@ class Job {
   toSummary() {
     return {
       jobId: this.jobId,
-      repo: this.repo,
-      branch: this.branch,
       status: this.status,
       duration: this.getDuration(),
       artifactCount: this.artifacts.length,
@@ -152,8 +146,6 @@ class Job {
   toJSON() {
     return {
       jobId: this.jobId,
-      repo: this.repo,
-      branch: this.branch,
       command: this.command,
       channelId: this.channelId,
       projectDir: this.projectDir,
@@ -177,8 +169,6 @@ class Job {
   static fromJSON(json) {
     const job = new Job({
       jobId: json.jobId,
-      repo: json.repo,
-      branch: json.branch,
       command: json.command,
       channelId: json.channelId,
       projectDir: json.projectDir,

--- a/src/opencode-core.js
+++ b/src/opencode-core.js
@@ -23,7 +23,7 @@ function createInstanceManager(options = {}) {
   /**
    * Start a new OpenCode instance
    */
-  function startInstance(instanceId, projectDir, channel) {
+  function startInstance(instanceId, projectDir, channel, opts = {}) {
     if (instances.has(instanceId)) {
       return { success: false, error: `Instance "${instanceId}" already running` };
     }

--- a/src/sprite-orchestrator.js
+++ b/src/sprite-orchestrator.js
@@ -77,8 +77,6 @@ class SpriteOrchestrator extends EventEmitter {
       JOB_ID: job.jobId,
       JOB_TOKEN: job.jobToken,
       OPEN_DISPATCH_URL: this.openDispatchUrl,
-      REPO: job.repo || '',
-      BRANCH: job.branch || 'main',
       COMMAND: job.command || '',
       GH_TOKEN: process.env.GH_TOKEN || '',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || '',
@@ -134,7 +132,7 @@ class SpriteOrchestrator extends EventEmitter {
    * @returns {Promise<Object>} Machine info
    */
   async spawnPersistent(options = {}) {
-    const { repo, branch = 'main', image, env = {} } = options;
+    const { image, env = {} } = options;
     const spriteImage = image || this.baseImage;
 
     try {
@@ -146,8 +144,6 @@ class SpriteOrchestrator extends EventEmitter {
           config: {
             image: spriteImage,
             env: {
-              REPO: repo || '',
-              BRANCH: branch,
               PERSISTENT: 'true',
               OPEN_DISPATCH_URL: this.openDispatchUrl,
               GH_TOKEN: process.env.GH_TOKEN || '',
@@ -172,7 +168,7 @@ class SpriteOrchestrator extends EventEmitter {
       }
 
       const machineInfo = await response.json();
-      this.emit('sprite:persistent:started', { machineInfo, repo, branch });
+      this.emit('sprite:persistent:started', { machineInfo });
       return machineInfo;
     } catch (error) {
       this.emit('sprite:error', { error });

--- a/tests/bot-engine.test.js
+++ b/tests/bot-engine.test.js
@@ -1,0 +1,261 @@
+/**
+ * Tests for bot-engine unified command parsing
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const { createBotEngine, _test } = require('../src/bot-engine');
+
+/**
+ * Create a mock chat provider
+ */
+function createMockChatProvider() {
+  const sent = [];
+  const cards = [];
+  const commandHandlers = [];
+  const messageHandlers = [];
+  const errorHandlers = [];
+
+  return {
+    name: 'mock',
+    supportsCards: false,
+    sent,
+    cards,
+    commandHandlers,
+    messageHandlers,
+
+    async initialize() {},
+    async start() {},
+    async stop() {},
+    async sendMessage(channelId, text) {
+      sent.push({ channelId, text });
+      return { messageId: 'msg-1' };
+    },
+    async sendLongMessage(channelId, text) {
+      sent.push({ channelId, text });
+    },
+    async sendCard(channelId, card) {
+      cards.push({ channelId, card });
+    },
+    async deleteMessage() {},
+    async sendTypingIndicator() {},
+
+    onCommand(handler) {
+      commandHandlers.push(handler);
+    },
+    onMessage(handler) {
+      messageHandlers.push(handler);
+    },
+    onError(handler) {
+      errorHandlers.push(handler);
+    },
+
+    // Helper to simulate a command
+    async simulateCommand(command, args, channelId = 'C123') {
+      const ctx = {
+        channelId,
+        reply: async (text) => { sent.push({ channelId, text }); }
+      };
+      for (const h of commandHandlers) {
+        await h(ctx, command, args);
+      }
+    }
+  };
+}
+
+/**
+ * Create a mock AI backend (local-mode style, no jobs map)
+ */
+function createMockLocalBackend() {
+  const instances = new Map();
+  const startCalls = [];
+
+  return {
+    startCalls,
+    startInstance(instanceId, projectDir, channelId, opts = {}) {
+      startCalls.push({ instanceId, projectDir, channelId, opts });
+      if (instances.has(instanceId)) {
+        return { success: false, error: `Instance "${instanceId}" already running` };
+      }
+      instances.set(instanceId, { projectDir, channelId, opts, startedAt: new Date(), messageCount: 0 });
+      return { success: true, sessionId: 'session-abc' };
+    },
+    stopInstance(instanceId) {
+      if (!instances.has(instanceId)) {
+        return { success: false, error: `Instance "${instanceId}" not found` };
+      }
+      instances.delete(instanceId);
+      return { success: true };
+    },
+    getInstance(instanceId) {
+      return instances.get(instanceId) || null;
+    },
+    getInstanceByChannel(channelId) {
+      for (const [instanceId, instance] of instances) {
+        if (instance.channelId === channelId) return { instanceId, instance };
+      }
+      return null;
+    },
+    listInstances() {
+      return Array.from(instances.entries()).map(([instanceId, inst]) => ({
+        instanceId, ...inst
+      }));
+    },
+    async sendToInstance(instanceId, message, options = {}) {
+      const inst = instances.get(instanceId);
+      if (!inst) return { success: false, error: 'not found' };
+      inst.messageCount++;
+      return { success: true, responses: ['done'], exitCode: 0 };
+    }
+  };
+}
+
+describe('Bot Engine — Unified Commands', () => {
+  let chatProvider;
+  let aiBackend;
+
+  beforeEach(() => {
+    chatProvider = createMockChatProvider();
+    aiBackend = createMockLocalBackend();
+    createBotEngine({ chatProvider, aiBackend, commandPrefix: 'od', aiName: 'TestAI' });
+  });
+
+  describe('generateName', () => {
+    it('should produce unique short IDs', () => {
+      const a = _test.generateName();
+      const b = _test.generateName();
+      assert.ok(a.startsWith('agent-'));
+      assert.ok(b.startsWith('agent-'));
+      assert.strictEqual(a.length, 10); // 'agent-' + 4 hex chars
+      // Statistically unique
+      assert.notStrictEqual(a, b);
+    });
+  });
+
+  describe('handleStart', () => {
+    it('should auto-generate name and default path when no args', async () => {
+      await chatProvider.simulateCommand('start', '');
+      assert.strictEqual(aiBackend.startCalls.length, 1);
+      const call = aiBackend.startCalls[0];
+      assert.ok(call.instanceId.startsWith('agent-'));
+      assert.strictEqual(call.projectDir, os.homedir());
+    });
+
+    it('should use provided name only', async () => {
+      await chatProvider.simulateCommand('start', 'mybot');
+      const call = aiBackend.startCalls[0];
+      assert.strictEqual(call.instanceId, 'mybot');
+      assert.strictEqual(call.projectDir, os.homedir());
+    });
+
+    it('should use provided name and path', async () => {
+      await chatProvider.simulateCommand('start', 'mybot /tmp/code');
+      const call = aiBackend.startCalls[0];
+      assert.strictEqual(call.instanceId, 'mybot');
+      assert.strictEqual(call.projectDir, '/tmp/code');
+    });
+
+    it('should extract --image flag', async () => {
+      await chatProvider.simulateCommand('start', '--image my-agent');
+      const call = aiBackend.startCalls[0];
+      assert.ok(call.instanceId.startsWith('agent-'));
+      assert.deepStrictEqual(call.opts, { image: 'my-agent' });
+    });
+
+    it('should handle name + --image', async () => {
+      await chatProvider.simulateCommand('start', 'mybot --image custom:v1');
+      const call = aiBackend.startCalls[0];
+      assert.strictEqual(call.instanceId, 'mybot');
+      assert.deepStrictEqual(call.opts, { image: 'custom:v1' });
+    });
+
+    it('should handle --image with auto-name', async () => {
+      await chatProvider.simulateCommand('start', '--image my-agent');
+      const call = aiBackend.startCalls[0];
+      assert.ok(call.instanceId.startsWith('agent-'));
+      assert.strictEqual(call.opts.image, 'my-agent');
+    });
+
+    it('should handle path that starts with /', async () => {
+      await chatProvider.simulateCommand('start', '/home/user/project');
+      const call = aiBackend.startCalls[0];
+      assert.ok(call.instanceId.startsWith('agent-'));
+      assert.strictEqual(call.projectDir, '/home/user/project');
+    });
+
+    it('should handle path that starts with ~', async () => {
+      await chatProvider.simulateCommand('start', '~/project');
+      const call = aiBackend.startCalls[0];
+      assert.ok(call.instanceId.startsWith('agent-'));
+      assert.strictEqual(call.projectDir, '~/project');
+    });
+  });
+
+  describe('handleRun', () => {
+    it('should show usage when no task provided', async () => {
+      await chatProvider.simulateCommand('run', '');
+      assert.ok(chatProvider.sent.some(m => m.text && m.text.includes('Usage')));
+      assert.strictEqual(aiBackend.startCalls.length, 0);
+    });
+
+    it('should run task with auto-generated name', async () => {
+      await chatProvider.simulateCommand('run', 'fix the tests');
+      assert.strictEqual(aiBackend.startCalls.length, 1);
+      const call = aiBackend.startCalls[0];
+      assert.ok(call.instanceId.startsWith('agent-'));
+    });
+
+    it('should extract --image flag from run args', async () => {
+      await chatProvider.simulateCommand('run', '--image custom "fix tests"');
+      // The instance was started (the run creates a temp instance)
+      assert.strictEqual(aiBackend.startCalls.length, 1);
+    });
+
+    it('should work with local backend (no jobs map)', async () => {
+      // Our mock backend has no .jobs property, proving the guard is removed
+      assert.strictEqual(aiBackend.jobs, undefined);
+      await chatProvider.simulateCommand('run', 'do something');
+      assert.strictEqual(aiBackend.startCalls.length, 1);
+    });
+  });
+
+  describe('handleStop', () => {
+    it('should stop a named instance', async () => {
+      await chatProvider.simulateCommand('start', 'mybot');
+      await chatProvider.simulateCommand('stop', 'mybot');
+      assert.strictEqual(aiBackend.getInstance('mybot'), null);
+    });
+
+    it('should show usage when no args', async () => {
+      await chatProvider.simulateCommand('stop', '');
+      assert.ok(chatProvider.sent.some(m => m.text && m.text.includes('Usage')));
+    });
+
+    it('should stop all instances with --all', async () => {
+      await chatProvider.simulateCommand('start', 'bot-a');
+      await chatProvider.simulateCommand('start', 'bot-b');
+      assert.strictEqual(aiBackend.listInstances().length, 2);
+
+      await chatProvider.simulateCommand('stop', '--all');
+      assert.strictEqual(aiBackend.listInstances().length, 0);
+    });
+
+    it('should report when --all has nothing to stop', async () => {
+      await chatProvider.simulateCommand('stop', '--all');
+      assert.ok(chatProvider.sent.some(m => m.text && m.text.includes('No instances running')));
+    });
+  });
+
+  describe('help text', () => {
+    it('should show unified commands on unknown command', async () => {
+      await chatProvider.simulateCommand('unknown', '');
+      const helpMsg = chatProvider.sent.find(m => m.text && m.text.includes('Available commands'));
+      assert.ok(helpMsg);
+      assert.ok(helpMsg.text.includes('--image'));
+      assert.ok(helpMsg.text.includes('--all'));
+      assert.ok(!helpMsg.text.includes('--repo'));
+      assert.ok(!helpMsg.text.includes('--branch'));
+    });
+  });
+});

--- a/tests/bot-engine.test.js
+++ b/tests/bot-engine.test.js
@@ -218,6 +218,12 @@ describe('Bot Engine — Unified Commands', () => {
       assert.ok(call.instanceId.startsWith('agent-'));
       assert.strictEqual(call.projectDir, 'projects/api');
     });
+
+    it('should error when --image has no value', async () => {
+      await chatProvider.simulateCommand('start', '--image');
+      assert.ok(chatProvider.sent.some(m => m.text && m.text.includes('Missing value for --image')));
+      assert.strictEqual(aiBackend.startCalls.length, 0);
+    });
   });
 
   describe('handleRun', () => {
@@ -252,6 +258,19 @@ describe('Bot Engine — Unified Commands', () => {
       assert.strictEqual(aiBackend.startCalls.length, 1);
       // The task should be the full quoted string, --image NOT extracted as a flag
       // (sendToInstance receives the task text)
+    });
+
+    it('should error when --image has no value', async () => {
+      await chatProvider.simulateCommand('run', '--image');
+      assert.ok(chatProvider.sent.some(m => m.text && m.text.includes('Missing value for --image')));
+      assert.strictEqual(aiBackend.startCalls.length, 0);
+    });
+
+    it('should pass image to startInstance opts', async () => {
+      await chatProvider.simulateCommand('run', '--image custom:v1 "fix tests"');
+      assert.strictEqual(aiBackend.startCalls.length, 1);
+      const call = aiBackend.startCalls[0];
+      assert.deepStrictEqual(call.opts, { image: 'custom:v1' });
     });
   });
 

--- a/tests/job.test.js
+++ b/tests/job.test.js
@@ -11,8 +11,6 @@ describe('Job', () => {
 
   beforeEach(() => {
     job = new Job({
-      repo: 'owner/repo',
-      branch: 'main',
       command: 'claude -p "run tests"',
       channelId: 'C123',
       projectDir: 'owner/repo',
@@ -28,7 +26,7 @@ describe('Job', () => {
     });
 
     it('should use provided jobId', () => {
-      const custom = new Job({ jobId: 'custom-id', repo: 'r', command: 'c', channelId: 'ch' });
+      const custom = new Job({ jobId: 'custom-id', command: 'c', channelId: 'ch' });
       assert.strictEqual(custom.jobId, 'custom-id');
     });
 
@@ -37,16 +35,9 @@ describe('Job', () => {
     });
 
     it('should store all provided fields', () => {
-      assert.strictEqual(job.repo, 'owner/repo');
-      assert.strictEqual(job.branch, 'main');
       assert.strictEqual(job.command, 'claude -p "run tests"');
       assert.strictEqual(job.channelId, 'C123');
       assert.strictEqual(job.jobToken, 'test-token-abc');
-    });
-
-    it('should default branch to main', () => {
-      const j = new Job({ repo: 'r', command: 'c', channelId: 'ch' });
-      assert.strictEqual(j.branch, 'main');
     });
 
     it('should default timeoutMs to 600000', () => {
@@ -54,7 +45,7 @@ describe('Job', () => {
     });
 
     it('should accept custom timeoutMs', () => {
-      const j = new Job({ repo: 'r', command: 'c', channelId: 'ch', timeoutMs: 30000 });
+      const j = new Job({ command: 'c', channelId: 'ch', timeoutMs: 30000 });
       assert.strictEqual(j.timeoutMs, 30000);
     });
 
@@ -66,7 +57,7 @@ describe('Job', () => {
     it('should store callback references', () => {
       const onMsg = async () => {};
       const onDone = async () => {};
-      const j = new Job({ repo: 'r', command: 'c', channelId: 'ch', onMessage: onMsg, onComplete: onDone });
+      const j = new Job({ command: 'c', channelId: 'ch', onMessage: onMsg, onComplete: onDone });
       assert.strictEqual(j.onMessage, onMsg);
       assert.strictEqual(j.onComplete, onDone);
     });
@@ -217,7 +208,7 @@ describe('Job', () => {
     });
 
     it('should return true when activity exceeds timeout', () => {
-      job = new Job({ repo: 'r', command: 'c', channelId: 'ch', timeoutMs: 1 });
+      job = new Job({ command: 'c', channelId: 'ch', timeoutMs: 1 });
       job.start('m1');
       // Force lastActivityAt into the past
       job.lastActivityAt = new Date(Date.now() - 100);
@@ -225,7 +216,7 @@ describe('Job', () => {
     });
 
     it('should reset timeout on addLog', () => {
-      job = new Job({ repo: 'r', command: 'c', channelId: 'ch', timeoutMs: 50 });
+      job = new Job({ command: 'c', channelId: 'ch', timeoutMs: 50 });
       job.start('m1');
       job.lastActivityAt = new Date(Date.now() - 100);
       assert.strictEqual(job.isTimedOut(), true);
@@ -255,7 +246,6 @@ describe('Job', () => {
       job.addArtifact({ name: 'PR', url: 'http://example.com' });
       const summary = job.toSummary();
       assert.strictEqual(summary.jobId, job.jobId);
-      assert.strictEqual(summary.repo, 'owner/repo');
       assert.strictEqual(summary.status, JobStatus.RUNNING);
       assert.strictEqual(summary.artifactCount, 1);
       assert.strictEqual(summary.logCount, 1);
@@ -273,7 +263,6 @@ describe('Job', () => {
       const restored = Job.fromJSON(json);
 
       assert.strictEqual(restored.jobId, job.jobId);
-      assert.strictEqual(restored.repo, job.repo);
       assert.strictEqual(restored.status, JobStatus.COMPLETED);
       assert.strictEqual(restored.exitCode, 0);
       assert.strictEqual(restored.logs.length, 1);

--- a/tests/sprite-core.test.js
+++ b/tests/sprite-core.test.js
@@ -205,8 +205,7 @@ describe('Sprite Instance Manager', () => {
 
       // Simulate: after spawn, the webhook fires status=completed
       const sendPromise = manager.sendToInstance('test', 'run tests', {
-        onMessage: async () => {},
-        repo: 'owner/repo'
+        onMessage: async () => {}
       });
 
       // Give the spawn a moment to run
@@ -234,7 +233,6 @@ describe('Sprite Instance Manager', () => {
 
       const result = await manager.sendToInstance('timeout-test', 'slow task', {
         onMessage: async () => {},
-        repo: 'owner/repo',
         timeoutMs: 200 // short timeout for fast test
       });
 
@@ -267,7 +265,7 @@ describe('Sprite Instance Manager', () => {
       const jobs = manager.listJobs();
       const job = manager.getJob(jobs[0].jobId);
       assert.ok(job);
-      assert.strictEqual(job.repo, 'owner/repo');
+      assert.strictEqual(job.projectDir, 'owner/repo');
     });
   });
 
@@ -355,7 +353,6 @@ describe('Sprite Orchestrator (mocked)', () => {
 
       const { Job } = require('../src/job');
       const job = new Job({
-        repo: 'owner/repo',
         command: 'claude -p "test"',
         channelId: 'C123',
         jobToken: 'test-job-token'
@@ -366,8 +363,8 @@ describe('Sprite Orchestrator (mocked)', () => {
       assert.ok(capturedUrl.includes('/apps/test-app/machines'));
       assert.strictEqual(capturedBody.config.auto_destroy, true);
       assert.strictEqual(capturedBody.config.env.JOB_ID, job.jobId);
-      assert.strictEqual(capturedBody.config.env.REPO, 'owner/repo');
       assert.strictEqual(capturedBody.config.env.COMMAND, 'claude -p "test"');
+      assert.strictEqual(capturedBody.config.env.REPO, undefined);
       assert.strictEqual(job.status, JobStatus.RUNNING);
       assert.strictEqual(job.machineId, 'machine-abc');
     });
@@ -384,7 +381,7 @@ describe('Sprite Orchestrator (mocked)', () => {
       });
 
       const { Job } = require('../src/job');
-      const job = new Job({ repo: 'r', command: 'c', channelId: 'ch' });
+      const job = new Job({ command: 'c', channelId: 'ch' });
 
       await assert.rejects(
         () => orch.spawnJob(job),

--- a/tests/sprite-integration.test.js
+++ b/tests/sprite-integration.test.js
@@ -101,9 +101,7 @@ describe('Sprite Integration', () => {
     // 2. Send task (this creates a Job and spawns a Machine)
     const chatMessages = [];
     const sendPromise = manager.sendToInstance('integration-test', 'run the tests', {
-      onMessage: async (text) => { chatMessages.push(text); },
-      repo: 'owner/repo',
-      branch: 'main'
+      onMessage: async (text) => { chatMessages.push(text); }
     });
 
     // 3. Give spawn a moment
@@ -170,8 +168,7 @@ describe('Sprite Integration', () => {
     await manager.startInstance('fail-test', 'owner/repo', 'C123');
 
     const sendPromise = manager.sendToInstance('fail-test', 'run broken thing', {
-      onMessage: async () => {},
-      repo: 'owner/repo'
+      onMessage: async () => {}
     });
 
     await new Promise(r => setTimeout(r, 50));
@@ -196,8 +193,7 @@ describe('Sprite Integration', () => {
     await manager.startInstance('auth-test', 'owner/repo', 'C123');
 
     const sendPromise = manager.sendToInstance('auth-test', 'task', {
-      onMessage: async () => {},
-      repo: 'owner/repo'
+      onMessage: async () => {}
     });
 
     await new Promise(r => setTimeout(r, 50));
@@ -222,8 +218,7 @@ describe('Sprite Integration', () => {
 
     // Start a job (don't await — we just want it in the map)
     const sendPromise = manager.sendToInstance('health-test', 'task', {
-      onMessage: async () => {},
-      repo: 'owner/repo'
+      onMessage: async () => {}
     });
 
     await new Promise(r => setTimeout(r, 50));
@@ -257,13 +252,11 @@ describe('Sprite Integration', () => {
     const messagesB = [];
 
     const promiseA = manager.sendToInstance('job-a', 'task A', {
-      onMessage: async (text) => { messagesA.push(text); },
-      repo: 'owner/repo-a'
+      onMessage: async (text) => { messagesA.push(text); }
     });
 
     const promiseB = manager.sendToInstance('job-b', 'task B', {
-      onMessage: async (text) => { messagesB.push(text); },
-      repo: 'owner/repo-b'
+      onMessage: async (text) => { messagesB.push(text); }
     });
 
     await new Promise(r => setTimeout(r, 50));


### PR DESCRIPTION
## Summary

- **Remove `--repo` and `--branch` flags** from all commands — repo cloning is the image creator's responsibility, not OD's
- **Make `name` optional** everywhere — auto-generates short IDs like `agent-7k3f` when omitted
- **Make `path` optional** in `/od-start` — defaults to `$HOME` (local mode) or ignored (Sprite mode)
- **Remove Sprite-only guard** from `/od-run` — works in both local and Sprite mode now
- **Add `/od-stop --all`** — stops all running agents in one command
- **Unified help text and README** — single command table instead of separate Local/Sprite sections

### Unified Command Spec

```
/od-start [name] [--image alias] [path]   → persistent conversation agent
/od-run [--image alias] <task>             → ephemeral fire-and-forget
/od-stop <name> | --all                    → stop agent(s)
/od-list                                   → list active agents
/od-jobs                                   → list recent jobs
```

### Files Changed

| File | What |
|------|------|
| `src/bot-engine.js` | New `generateName()`, `parseStartArgs()`, unified handlers, `--all` support |
| `src/job.js` | Removed `repo`/`branch` fields from constructor, serialization |
| `src/sprite-core.js` | Removed `repo`/`branch` from instance state and send methods |
| `src/sprite-orchestrator.js` | Removed `REPO`/`BRANCH` env vars from Machine spawning |
| `src/claude-core.js`, `src/opencode-core.js` | Added `opts = {}` param for uniform interface |
| `tests/bot-engine.test.js` | **New** — 19 tests for unified command parsing |
| `tests/job.test.js`, `tests/sprite-core.test.js`, `tests/sprite-integration.test.js` | Updated to remove repo/branch |
| `README.md` | Unified command table, updated examples and agent instructions |

## Test plan

- [x] All 173 tests pass (`npm test`)
- [ ] Manual: `/od-start` with no args auto-generates name, uses $HOME
- [ ] Manual: `/od-start mybot /path` works as before
- [ ] Manual: `/od-run "fix tests"` works in local mode (no Sprite guard)
- [ ] Manual: `/od-stop --all` stops all instances
- [ ] Manual: `--image` flag passes through correctly in Sprite mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)